### PR TITLE
Update to grunt 0.4, and node 0.10 GH-6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10
 before_script:
   - npm install -g grunt-cli

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Ryan Leckey (https://github.com/mehcode)
 Andrew Jones (https://github.com/andrewrjones)
+Hardy Jones (https://github.com/joneshf)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-haml [![Build Status](https://travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
+# grunt-haml [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
 
 > Compile Haml files to JavaScript.
 
@@ -170,4 +170,4 @@ haml: {
 
 Task submitted by [Ryan Leckey](https://github.com/mehcode)
 
-*This file was generated on Fri Mar 22 2013 15:55:32.*
+*This file was generated on Tue Apr 02 2013 15:25:59.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-haml [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
+# grunt-haml [![Build Status](https://travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
 
 > Compile Haml files to JavaScript.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-haml [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
+# grunt-haml [![Build Status](https://travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
 
 > Compile Haml files to JavaScript.
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "test": "grunt test"
   },
   "engines": {
-    "node": "0.8.x"
+    "node": "0.10.x"
   },
   "dependencies": {
-    "grunt-lib-contrib": "0.4.x",
     "haml": "0.4.x",
     "haml-coffee": "1.8.x"
   },

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -21,11 +21,11 @@ module.exports = function(grunt) {
     // Iterate through files.
     this.files.forEach(function(file) {
       // Get only files that are actually there.
-      var validFiles = file.src.filter(function(path) {
-        if (grunt.file.exists(path)) {
+      var validFiles = file.src.filter(function(filepath) {
+        if (grunt.file.exists(filepath)) {
           return true;
         } else {
-          grunt.log.warn('Source file "' + path + '" not found.');
+          grunt.log.warn('Source file "' + filepath + '" not found.');
           return false;
         }
       });

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -20,6 +20,14 @@ module.exports = function(grunt) {
 
     // Iterate through files.
     this.files.forEach(function(file) {
+      var validFiles = file.src.filter(function(path) {
+        if (!grunt.file.exists(path)) {
+          grunt.log.warn('Source file "' + path + '" not found.');
+          return false;
+        } else {
+          return true;
+        }
+      });
       // Ensure we have files to compile.
       if (file.src.length === 0) {
         grunt.log.writeln('Unable to compile; no valid files were found.');

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -20,31 +20,30 @@ module.exports = function(grunt) {
 
     // Iterate through files.
     this.files.forEach(function(file) {
+      // Get only files that are actually there.
       var validFiles = file.src.filter(function(path) {
-        if (!grunt.file.exists(path)) {
+        if (grunt.file.exists(path)) {
+          return true;
+        } else {
           grunt.log.warn('Source file "' + path + '" not found.');
           return false;
-        } else {
-          return true;
         }
       });
+
       // Ensure we have files to compile.
-      if (file.src.length === 0) {
+      if (validFiles.length === 0) {
         grunt.log.writeln('Unable to compile; no valid files were found.');
         return;
       }
 
-      // Compile each file; concatenating them into the source if desired.
-      var output = [];
-      file.src.forEach(function(file) {
-        output.push(transpile(file, options));
+      // Read each valid file and transpile it.
+      var output = validFiles.map(function (source) {
+        return transpile(grunt.file.read(source, options));
       });
 
-      // If we managed to get anything; let the world know.
-      if (output.length > 0) {
-        grunt.file.write(file.dest, output.join('\n') || '');
-        grunt.log.writeln('File ' + file.dest.cyan + ' created.');
-      }
+      // Write the new file.
+      grunt.file.write(file.dest, output.join('\n'));
+      grunt.log.writeln('File ' + file.dest.cyan + ' created.');
     });
   });
 

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -38,6 +38,7 @@ module.exports = function(grunt) {
     // Write options iff verbose.
     grunt.verbose.writeflags(options, 'Options');
 
+    // Transpile each src/dest group of files.
     this.files.forEach(function(file) {
 
       // Get only files that are actually there.
@@ -50,7 +51,7 @@ module.exports = function(grunt) {
         }
       });
 
-      // Ensure we have files to compile.
+      // Ensure we have files to transpile.
       if (validFiles.length > 0) {
         // Transpile each file.
         var output = validFiles.map(function (filename) {
@@ -82,108 +83,21 @@ module.exports = function(grunt) {
       template = path.basename(name, path.extname(name));
     }
 
-    // Remove options not understood by any compiler.
-    delete options.language;
-    delete options.target;
-    delete options.name;
-    delete options.context;
+    // // Remove options not understood by any compiler.
+    // delete options.language;
+    // delete options.target;
+    // delete options.name;
+    // delete options.context;
 
     // Read in the file
     var input = grunt.file.read(name);
+    options.input = input;
+    options.template = template;
 
     try {
-
       switch (language) {
-      case 'js':
-        var haml = require('haml');
-
-        // First pass; generate the javascript method.
-        output = haml(input);
-
-        if (target === 'html') {
-          // Evaluate method with the context and return it.
-          return output(context);
-        } else if (target !== 'js') {
-          grunt.fail.warn(
-            'Target ' + target + ' is not a valid ' +
-            'destination target for `haml-coffee`; choices ' +
-            'are: html and js\n');
-        }
-
-        // Reduce to a true annoymous, unnamed method.
-        // TODO: Push this upstream.
-        output = output.toString().substring(27);
-        output = 'function(locals)' + output;
-
-        switch (options.placement) {
-        case 'global':
-          // Set in the desired namespace.
-          output = options.namespace + "['" + template + "'] = " + output;
-          output = '\n' + output + '\n';
-          break;
-
-        case 'amd':
-          // Search for additional dependencies
-          var lookup = /require.*?\(.*?["'](.*)["'].*?\)/g;
-          var extra = lookup.exec(input);
-          while (extra !== null) {
-            var base = path.basename(extra[1]);
-            options.dependencies[base] = extra[1];
-            extra = lookup.exec(input);
-          }
-
-          // Build define statement.
-          var defineStatement = 'define([';
-          var modules = _(options.dependencies).values();
-          modules = modules.length ? "'" + modules.join("','") + "'" : "";
-          defineStatement += modules;
-          defineStatement += '], function(';
-          defineStatement += _(options.dependencies).keys().join(',');
-          defineStatement += ') { \n';
-
-          // Wrap ouptut in it.
-          output = defineStatement + 'return ' + output + ';\n});\n';
-          break;
-
-        default:
-          grunt.fail.warn(
-            'Placement ' + options.placement + ' is not a valid ' +
-            'destination placement for `haml-js`; choices ' +
-            'are: amd and global\n');
-        }
-
-        // Return the final template.
-        return output;
-
-      case 'coffee':
-        var hamlc = require('haml-coffee');
-        var namespace = options.namespace;
-
-        // Remove options not understood by the compiler.
-        delete options.namespace;
-
-        switch (target) {
-        case 'js':
-          // Pass it off to haml-coffee to render a template in javascript.
-          return hamlc.template(input, template, namespace, options);
-
-        case 'html':
-          // Pass it off to haml-coffee to render a template in javascript.
-          output = hamlc.compile(input, options);
-
-          // Now we render it as HTML with the given context.
-          return output(context);
-
-        default:
-          grunt.fail.warn(
-            'Target ' + target + ' is not a valid ' +
-            'destination target for `haml-coffee`; choices ' +
-            'are: html and js\n');
-        }
-
-        // Shouldn't be able to get here -- but just in case.
-        break;
-
+      case 'js': return transpileJs(options);
+      case 'coffee': return transpileCoffee(options);
       default:
         grunt.fail.warn(
           'Language ' + language + ' is not a valid ' +
@@ -194,5 +108,99 @@ module.exports = function(grunt) {
       grunt.log.error(e);
       grunt.fail.warn('Haml failed to compile.');
     }
+  };
+
+  var transpileJs = function(options) {
+
+    var haml = require('haml');
+    var output = null;
+
+    // First pass; generate the javascript method.
+    output = haml(options.input);
+
+    if (options.target === 'html') {
+      // Evaluate method with the context and return it.
+      return output(options.context);
+    } else if (options.target !== 'js') {
+      grunt.fail.warn(
+        'Target ' + options.target + ' is not a valid ' +
+        'destination target for `haml-coffee`; choices ' +
+        'are: html and js\n');
+    }
+
+    // Reduce to a true annoymous, unnamed method.
+    // TODO: Push this upstream.
+    output = output.toString().substring(27);
+    output = 'function(locals)' + output;
+
+    switch (options.placement) {
+    case 'global':
+      // Set in the desired namespace.
+      output = options.namespace + "['" + options.template + "'] = " + output;
+      output = '\n' + output + '\n';
+      break;
+
+    case 'amd':
+      // Search for additional dependencies
+      var lookup = /require.*?\(.*?["'](.*)["'].*?\)/g;
+      var extra = lookup.exec(options.input);
+      while (extra !== null) {
+        var base = path.basename(extra[1]);
+        options.dependencies[base] = extra[1];
+        extra = lookup.exec(options.input);
+      }
+
+      // Build define statement.
+      var defineStatement = 'define([';
+      var modules = _(options.dependencies).values();
+      modules = modules.length ? "'" + modules.join("','") + "'" : "";
+      defineStatement += modules;
+      defineStatement += '], function(';
+      defineStatement += _(options.dependencies).keys().join(',');
+      defineStatement += ') { \n';
+
+      // Wrap ouptut in it.
+      output = defineStatement + 'return ' + output + ';\n});\n';
+      break;
+
+    default:
+      grunt.fail.warn(
+        'Placement ' + options.placement + ' is not a valid ' +
+        'destination placement for `haml-js`; choices ' +
+        'are: amd and global\n');
+    }
+
+    // Return the final template.
+    return output;
+  };
+
+  var transpileCoffee = function(options) {
+    var hamlc = require('haml-coffee');
+    var namespace = options.namespace;
+    var output = null;
+
+    // Remove options not understood by the compiler.
+    delete options.namespace;
+
+    switch (options.target) {
+    case 'js':
+      // Pass it off to haml-coffee to render a template in javascript.
+      return hamlc.template(options.input, options.template, options.namespace,
+        options);
+
+    case 'html':
+      // Pass it off to haml-coffee to render a template in javascript.
+      output = hamlc.compile(options.input, options);
+
+      // Now we render it as HTML with the given context.
+      return output(options.context);
+
+    default:
+      grunt.fail.warn(
+        'Target ' + options.target + ' is not a valid ' +
+        'destination target for `haml-coffee`; choices ' +
+        'are: html and js\n');
+    }
+
   };
 };

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -32,13 +32,13 @@ module.exports = function(grunt) {
       dependencies: {}
     });
 
-    // Write options iff verbose.
-    grunt.verbose.writeflags(defaultOptions, 'Options');
+    // Set the target options.
+    var options = this.options(defaultOptions);
 
-    // Iterate through files.
+    // Write options iff verbose.
+    grunt.verbose.writeflags(options, 'Options');
+
     this.files.forEach(function(file) {
-      // Set the target options.
-      var options = this.options(defaultOptions);
 
       // Get only files that are actually there.
       var validFiles = file.src.filter(function(filepath) {

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -12,10 +12,8 @@ module.exports = function(grunt) {
   var _    = grunt.util._;
 
   grunt.registerMultiTask('haml', 'Compile Haml files', function() {
-    var helpers = require('grunt-lib-contrib').init(grunt);
-    var defaultOptions = helpers.options(this);
-    // Set up some defaults for the options.
-    _.defaults(defaultOptions, {
+    // Set the target options with some defaults.
+    var options = this.options({
       // Default target is javascript.
       target: 'html',
 
@@ -31,9 +29,6 @@ module.exports = function(grunt) {
       // Default hash of dependencies for AMD.
       dependencies: {}
     });
-
-    // Set the target options.
-    var options = this.options(defaultOptions);
 
     // Write options iff verbose.
     grunt.verbose.writeflags(options, 'Options');
@@ -55,8 +50,7 @@ module.exports = function(grunt) {
       if (validFiles.length > 0) {
         // Transpile each file.
         var output = validFiles.map(function (filename) {
-          // Pass in a copy so we don't mutate the original target options.
-          return transpile(filename, _.cloneDeep(options));
+          return transpile(filename, options);
         });
         // Write the new file.
         grunt.file.write(file.dest, output.join('\n'));
@@ -67,7 +61,10 @@ module.exports = function(grunt) {
     });
   });
 
-  var transpile = function(name, options) {
+  var transpile = function(name, opts) {
+    // Construct appropriate options to pass to the compiler
+    // Create a new object so we do not mutate the target options.
+    var options = _.extend({filename: name}, opts);
     // Read in the file
     options.input = grunt.file.read(name);
 


### PR DESCRIPTION
So I don't have push access to the original repo.  But this should be for issue 6: https://github.com/concordusapps/grunt-haml/issues/6

I had a concern though, we were using `helpers.options` in the task.  Is that necessary for something?  It seems that `this.options` provides the task with the options defined in `Gruntfile.js`.  Or is there something else that is going on?  I removed the dependency for `grunt-lib-contrib` if we don't need that helper anymore.  If so, I can add that back in.  I also tried to clean up the transpile function a bit, so that it is easier to read and maintain.  Hopefully that should make adding additional languages easier.

Updated to node 0.10.x.  The tests pass on my machine with `npm test`, dunno about travis yet though.  I lied, travis is all good.
