### PR TITLE
Added support for Ruby haml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - 0.10
 before_script:
   - npm install -g grunt-cli
+  - gem install haml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,11 +144,29 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-internal');
 
+  // The grunt-contrib-internal task defaults to the wrong URL for travis
+  grunt.registerTask('fix-readme', 'Fix travis URL in README.md', function () {
+    grunt.task.requires('build-contrib');
+
+    var fs = require('fs');
+    var readme = fs.readFileSync('README.md', {encoding: "utf-8"});
+    readme = readme.replace(
+      /travis-ci.org\/gruntjs/,
+      'travis-ci.org/concordusapps'
+    );
+    fs.writeFileSync('README.md', readme);
+    return true;
+  });
+
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
   grunt.registerTask('test', ['clean', 'haml', 'nodeunit']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);
-
+  grunt.registerTask('default', [
+    'jshint',
+    'test',
+    'build-contrib',
+    'fix-readme']
+  );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,18 @@ module.exports = function(grunt) {
             'test/fixtures/js/js2.haml'
           ]
         }
+      },
+      'ruby_html': {
+        options: {
+          language: 'ruby'
+        },
+        files: {
+          'tmp/ruby_html/haml.html': 'test/fixtures/ruby/ruby1.haml',
+          'tmp/ruby_html/concat.html': [
+            'test/fixtures/ruby/ruby1.haml',
+            'test/fixtures/ruby/ruby2.haml'
+          ]
+        }
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,7 +151,7 @@ module.exports = function(grunt) {
     var fs = require('fs');
     var readme = fs.readFileSync('README.md', {encoding: "utf-8"});
     readme = readme.replace(
-      /travis-ci.org\/gruntjs/,
+      /travis-ci.org\/gruntjs/g,
       'travis-ci.org/concordusapps'
     );
     fs.writeFileSync('README.md', readme);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# grunt-haml [![Build Status](https://travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
+# grunt-haml [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
 
-> Process HAML templates to precompiled JavaScript or rendered HTML.
+> Compile Haml files to JavaScript.
 
 
 ## Getting Started
@@ -29,11 +29,14 @@ Default: ```js```
 
 Specifies the script language and compiler to use alongside HAML.
 
-Accepts following values: ```coffee``` or ```js``` in which it will use
-[haml-coffee][] or [haml-js][] respectively.
+Accepts following values: ```coffee```, ```js```, or ```ruby```.
+If given ```coffee``` or ```js``` it will use
+[haml-coffee][] or [haml-js][] respectively. If given ```ruby``` it will
+shell out to the [haml gem] executable.
 
 [haml-coffee]: https://github.com/netzpirat/haml-coffee
 [haml-js]: https://github.com/creationix/haml-js
+[haml gem]: http://rubygems.org/gems/haml
 
 #### target
 Type: ```string```
@@ -44,6 +47,9 @@ Specifies the target language to compile to.
 Accepts the following values: ```js``` or ```html```. For ```js``` the template
 is generated and for ```html``` the template is both generated and rendered
 into its resultant HTML.
+
+If ```language``` is set to ```ruby``` then ```target```
+must be set to ```html```.
 
 #### placement
 Type: ```string```
@@ -128,6 +134,15 @@ Compile the JavaScript without the top-level function safety wrapper.
 
 *Defined only for language == 'coffee' and target == 'js'.*
 
+#### rubyHamlCommand
+Type: ```string```
+Default: ```haml -t ugly```
+
+The shell command which will be ran to compile the HAML. The path to the
+HAML file will be passed as the last command-line argument.
+
+*Defined only for language == 'ruby'
+
 ### Usage examples
 
 ``` javascript
@@ -170,4 +185,4 @@ haml: {
 
 Task submitted by [Ryan Leckey](https://github.com/mehcode)
 
-*This file was generated on Tue Apr 02 2013 15:25:59.*
+*This file was generated on Tue Apr 16 2013 14:39:33.*

--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ haml: {
 
 Task submitted by [Ryan Leckey](https://github.com/mehcode)
 
-*This file was generated on Tue Apr 16 2013 14:39:33.*
+*This file was generated on Wed Apr 17 2013 10:47:10.*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-haml [![Build Status](https://secure.travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
 
-> Compile Haml files to JavaScript.
+> Process HAML templates to precompiled JavaScript or rendered HTML.
 
 
 ## Getting Started
@@ -185,4 +185,4 @@ haml: {
 
 Task submitted by [Ryan Leckey](https://github.com/mehcode)
 
-*This file was generated on Wed Apr 17 2013 10:47:10.*
+*This file was generated on Wed Apr 17 2013 10:48:40.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-haml [![Build Status](https://secure.travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
+# grunt-haml [![Build Status](https://secure.travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/concordusapps/grunt-haml)
 
 > Process HAML templates to precompiled JavaScript or rendered HTML.
 
@@ -185,4 +185,4 @@ haml: {
 
 Task submitted by [Ryan Leckey](https://github.com/mehcode)
 
-*This file was generated on Wed Apr 17 2013 10:48:40.*
+*This file was generated on Wed Apr 17 2013 10:59:19.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-haml [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
+# grunt-haml [![Build Status](https://secure.travis-ci.org/concordusapps/grunt-haml.png?branch=master)](http://travis-ci.org/gruntjs/grunt-haml)
 
 > Compile Haml files to JavaScript.
 

--- a/docs/haml-options.md
+++ b/docs/haml-options.md
@@ -6,11 +6,14 @@ Default: ```js```
 
 Specifies the script language and compiler to use alongside HAML.
 
-Accepts following values: ```coffee``` or ```js``` in which it will use
-[haml-coffee][] or [haml-js][] respectively.
+Accepts following values: ```coffee```, ```js```, or ```ruby```.
+If given ```coffee``` or ```js``` it will use
+[haml-coffee][] or [haml-js][] respectively. If given ```ruby``` it will
+shell out to the [haml gem] executable.
 
 [haml-coffee]: https://github.com/netzpirat/haml-coffee
 [haml-js]: https://github.com/creationix/haml-js
+[haml gem]: http://rubygems.org/gems/haml
 
 ## target
 Type: ```string```
@@ -21,6 +24,9 @@ Specifies the target language to compile to.
 Accepts the following values: ```js``` or ```html```. For ```js``` the template
 is generated and for ```html``` the template is both generated and rendered
 into its resultant HTML.
+
+If ```language``` is set to ```ruby``` then ```target```
+must be set to ```html```.
 
 ## placement
 Type: ```string```
@@ -104,3 +110,12 @@ Default: ```true```
 Compile the JavaScript without the top-level function safety wrapper.
 
 *Defined only for language == 'coffee' and target == 'js'.*
+
+## rubyHamlCommand
+Type: ```string```
+Default: ```haml -t ugly```
+
+The shell command which will be ran to compile the HAML. The path to the
+HAML file will be passed as the last command-line argument.
+
+*Defined only for language == 'ruby'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-haml",
-  "description": "Compile Haml files to JavaScript.",
+  "description": "Process HAML templates to precompiled JavaScript or rendered HTML.",
   "version": "0.4.0",
   "homepage": "https://github.com/concordusapps/grunt-haml",
   "author": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "haml": "0.4.x",
     "haml-coffee": "1.8.x",
-    "execSync": "*"
+    "execSync": "0.0.4"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "haml": "0.4.x",
-    "haml-coffee": "1.8.x"
+    "haml-coffee": "1.8.x",
+    "execSync": "*"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.1.x",

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -27,7 +27,10 @@ module.exports = function(grunt) {
       namespace: 'window.HAML',
 
       // Default hash of dependencies for AMD.
-      dependencies: {}
+      dependencies: {},
+
+      // External haml command to execute, must accept STDIN
+      rubyHamlCommand: 'haml -t ugly'
     });
 
     // Write options iff verbose.
@@ -78,6 +81,7 @@ module.exports = function(grunt) {
       switch (options.language) {
       case 'js': return transpileJs(options);
       case 'coffee': return transpileCoffee(options);
+      case 'ruby': return transpileRuby(options);
       default:
         grunt.fail.warn(
           'Language ' + options.language + ' is not a valid ' +
@@ -90,7 +94,6 @@ module.exports = function(grunt) {
   };
 
   var transpileJs = function(options) {
-
     var haml = require('haml');
 
     // First pass; generate the javascript method.
@@ -102,7 +105,7 @@ module.exports = function(grunt) {
     } else if (options.target !== 'js') {
       grunt.fail.warn(
         'Target ' + options.target + ' is not a valid ' +
-        'destination target for `haml-coffee`; choices ' +
+        'destination target for `haml-js`; choices ' +
         'are: html and js\n');
     }
 
@@ -172,5 +175,27 @@ module.exports = function(grunt) {
         'destination target for `haml-coffee`; choices ' +
         'are: html and js\n');
     }
+  };
+
+  var transpileRuby = function(options) {
+    var execSync = require('execSync');
+
+    if (options.context) {
+      grunt.fail.warn("Context is not a valid option for `haml-ruby`");
+    }
+
+    if (options.target !== 'html') {
+      grunt.fail.warn(
+        'Target ' + options.target + ' is not a valid ' +
+        'destination target for `haml-ruby`; choices ' +
+        'are: html\n');
+    }
+
+    var p = path.resolve(options.filename);
+    var result = execSync.exec(options.rubyHamlCommand + ' ' + p);
+    if (result.code !== 0) {
+      grunt.fail.warn("Error executing haml: " + result.stderr + result.stdout);
+    }
+    return result.stdout;
   };
 };

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -194,7 +194,11 @@ module.exports = function(grunt) {
     var p = path.resolve(options.filename);
     var result = execSync.exec(options.rubyHamlCommand + ' ' + p);
     if (result.code !== 0) {
-      grunt.fail.warn("Error executing haml: " + result.stderr + result.stdout);
+      grunt.fail.warn(
+        "Error executing haml on " + p + ": \n" +
+        result.stderr + "\n" +
+        result.stdout
+      );
     }
     return result.stdout;
   };

--- a/test/expected/ruby_html/concat.html
+++ b/test/expected/ruby_html/concat.html
@@ -1,0 +1,10 @@
+<div id='content'>
+<div class='left column' style='border-right: 1px solid black'>
+<h2>Welcome to our site!</h2>
+</div>
+<div class='right column' style='border-left: 1px solid black'>
+We hope you stick around
+</div>
+</div>
+
+<div>Hello</div>

--- a/test/expected/ruby_html/haml.html
+++ b/test/expected/ruby_html/haml.html
@@ -1,0 +1,8 @@
+<div id='content'>
+<div class='left column' style='border-right: 1px solid black'>
+<h2>Welcome to our site!</h2>
+</div>
+<div class='right column' style='border-left: 1px solid black'>
+We hope you stick around
+</div>
+</div>

--- a/test/fixtures/ruby/ruby1.haml
+++ b/test/fixtures/ruby/ruby1.haml
@@ -1,0 +1,5 @@
+#content
+  .left.column(style="border-right: 1px solid black")
+    %h2 Welcome to our site!
+  .right.column{:style => "border-left: 1px solid black"}
+    We hope you stick around

--- a/test/fixtures/ruby/ruby2.haml
+++ b/test/fixtures/ruby/ruby2.haml
@@ -1,0 +1,1 @@
+%div Hello


### PR DESCRIPTION
Sometimes I like to use the original haml implementation in Ruby to compile templates. It has a somewhat more forgiving parser than haml-js, particularly when it comes to dealing with long attribute lists, something that Angular is notorious for.

This pullreq adds support for shelling out to the `haml` command installed by the haml gem, if the `language` setting is set to `ruby`. I've also created some tests for this feature, doing a little refactoring of the existing test code in the process, and documented the new feature.
