### PR TITLE
Bump haml-coffee version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "haml": "0.4.x",
-    "haml-coffee": "1.8.x",
+    "haml-coffee": "1.10.x",
     "execSync": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Current haml-coffee is pretty old, needs update. tests pass fine after bump to 1.10.x.
