### PR TITLE
Fixes a bug where an error in ruby haml wouldn't bubble up

### DIFF
--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -254,7 +254,7 @@ module.exports = function(grunt) {
     var p = path.resolve(options.filename);
     var command = options.rubyHamlCommand + ' ' + p;
     var result = exec(command, function(error, stdout, stderr) {
-      if (result.error) {
+      if (error) {
         grunt.fail.warn(
           "Error executing haml on " + p + ": \n" +
           stderr + "\n" +


### PR DESCRIPTION
:wave: Hi, I'm Carol, and I'm a rubyist new to node, and actually a bit new to haml too.

I'm running grunt-haml using the ruby haml option. I noticed that when I made an error in my haml, grunt-haml would say it had succeeded, but I'd have an empty html file. I expected grunt-haml to fail and show me the errors that resulted from running the haml ruby gem.

I know just enough node to be dangerous, but it looks like in the [child-process.exec docs](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) the error is within the callback, but the call here was trying to use `result.error`.

I don't think the other compilation options have this problem since they don't use `exec`, but I didn't test them either.

When I use the code without this change on an invalid haml file, the task succeeds incorrectly, and with this change, the task fails correctly. I'm not sure how to write a test for this within the existing test structure, since the test would be "make sure compilation throws an error on this invalid haml file" and currently the haml task expects all the compilations to pass :-/
