### PR TITLE
rubyhaml error logging

### DIFF
--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -262,6 +262,14 @@ module.exports = function(grunt) {
         );
       }
 
+      if (stderr) {
+        grunt.log.warn(
+          "Error executing haml on " + p + ": \n" +
+          stderr + "\n" +
+          stdout
+        );
+      }
+
       output = stdout;
 
       if (options.wrapHtmlInJs) {


### PR DESCRIPTION
When using with option  `language: "ruby"` there is no warning when a malformed haml file is compiled.   I have now added a warning displaying the stderr if it exists.  It is logging a warning so that any livereload  is not interrupted.  
