### PR TITLE
Add `batchLimit` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ window.HAML['templates/example']
 
 *Defined only `placement == 'global'`.*
 
+#### batchLimit
+Type: ```number```
+Default: ```20```
+
+The maximum number of asynchronous transpiling processes simultaneously running at any time.   
+
 ### Usage examples
 
 ``` javascript

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "haml": "0.4.x",
     "haml-coffee": "1.14.x"
   },

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
   'use strict';
 
   var path = require('path');
-  var async = grunt.util.async;
+  var async = require('async');
   var _    = grunt.util._;
 
   grunt.registerMultiTask('haml', 'Compile Haml files', function() {
@@ -41,7 +41,10 @@ module.exports = function(grunt) {
 
       // Precompile templates; if false (and target == 'js'), place rendered
       // HTML in js variables.
-      precompile: true
+      precompile: true,
+      
+      // The maximum number of asynchronous transpiling processes simultaneously running at any time   
+      batchLimit: 20  
 
     });
 
@@ -52,7 +55,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     // Transpile each src/dest group of files.
-    async.forEach(this.files, function(file, callback) {
+    async.eachLimit(this.files, options.batchLimit, function(file, callback) {
       var opts;
       // Get only files that are actually there.
       var validFiles = file.src.filter(function(filepath) {


### PR DESCRIPTION
When running the task against big amount of `.haml` files it creates the same amount of async processes. Say, 1000 files spawns 1000 `ruby` processes when used with ruby command. That easily consumes all the available machine's memory and fails.

This PR adds support of [`async.eachLimit`](https://github.com/caolan/async#eachLimit) function which limits the concurrent amount of async processes; and `batchLimit` option to configure it.
