### PR TITLE
Adding `workers` option for specifying the number of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ window.HAML['templates/example']
 
 *Defined only `placement == 'global'`.*
 
+#### workers
+Type: ```number```
+Default: ```twice the number of CPUs```
+
+Limit the number of workers when running the task
+
+Set this to 1 if you want the task to be executed
+serially.
+
 ### Usage examples
 
 ``` javascript

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "haml": "0.4.x",
     "haml-coffee": "1.14.x"
   },


### PR DESCRIPTION
Set this to 1 if you want the task to be executed
serially. By default it equals to twice the number of CPUs
This should also close issue https://github.com/concordusapps/grunt-haml/issues/34
