### PR TITLE
Support for passing options into `exec'

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ HAML file will be passed as the last command-line argument.
 
 *Defined only for language == 'ruby'
 
+#### execOptions
+Type: ```object```
+Default: ```{}```
+
+Allows passing options into calls made to exec.
+
 #### includePath
 Type: ```boolean```
 Default: ```false```
@@ -237,7 +243,8 @@ haml: {
 
 
 ## Release History
-
+ 
+ * 2015-11-20   v0.9.1   Support passing options into calls to exec.
  * 2013-10-09   v0.8.0   Update version of haml-coffee 1.13.x Rendering to HTML with partials now works correctly
  * 2013-08-21   v0.7.0   Replace execSync with proper use of exec.
  * 2013-08-11   v0.6.1   Update version of haml-coffee 1.11.x

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-haml",
   "description": "Process HAML templates to precompiled JavaScript or rendered HTML.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/concordusapps/grunt-haml",
   "author": {
     "name": "Concordus Applications"

--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -39,6 +39,9 @@ module.exports = function(grunt) {
       // External haml command to execute, must accept STDIN
       rubyHamlCommand: 'haml -t ugly',
 
+      // Options passed into calls to exec
+      execOptions: {},
+
       // Precompile templates; if false (and target == 'js'), place rendered
       // HTML in js variables.
       precompile: true
@@ -253,7 +256,7 @@ module.exports = function(grunt) {
 
     var p = path.resolve(options.filename);
     var command = options.rubyHamlCommand + ' ' + p;
-    var result = exec(command, function(error, stdout, stderr) {
+    var result = exec(command, options.execOptions, function(error, stdout, stderr) {
       if (result.error || error) {
         grunt.fail.warn(
           "Error executing haml on " + p + ": \n" +


### PR DESCRIPTION
We required passing `maxBuffer` into `exec` to get around large HAML files.

```
  execOptions: {
    maxBuffer: 1024 * 500
  }
```

http://stackoverflow.com/questions/23429499/stdout-buffer-issue-using-node-child-process
